### PR TITLE
Default only_alternate_source to true

### DIFF
--- a/src/bsaextractor.cpp
+++ b/src/bsaextractor.cpp
@@ -57,13 +57,13 @@ QString BsaExtractor::description() const
 
 VersionInfo BsaExtractor::version() const
 {
-  return VersionInfo(1, 1, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 2, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> BsaExtractor::settings() const
 {
   return {
-    PluginSetting("only_alternate_source", "only trigger bsa extraction for alternate game sources", false)
+    PluginSetting("only_alternate_source", "only trigger bsa extraction for alternate game sources", true)
   };
 }
 


### PR DESCRIPTION
A bunch of users are freaking out about this 'new feature'
that used to be disabled by default. This will minimize
any unintentional damage by only giving the pop-up in
cases where it's likely to be desired.