### PR TITLE
Use wide strings with BSATK input / output paths

### DIFF
--- a/src/bsaextractor.cpp
+++ b/src/bsaextractor.cpp
@@ -93,8 +93,8 @@ void BsaExtractor::modInstalledHandler(IModInterface *mod) {
              QDialogButtonBox::No) == QDialogButtonBox::Yes);
     foreach (QFileInfo archiveInfo, archives) {
       BSA::Archive archive;
-      BSA::EErrorCode result = archive.read(
-          archiveInfo.absoluteFilePath().toLocal8Bit().constData(), true);
+      BSA::EErrorCode result =
+          archive.read(archiveInfo.absoluteFilePath().toStdWString().c_str(), true);
       if ((result != BSA::ERROR_NONE) && (result != BSA::ERROR_INVALIDHASHES)) {
         reportError(tr("failed to read %1: %2")
                         .arg(archiveInfo.fileName())
@@ -108,7 +108,7 @@ void BsaExtractor::modInstalledHandler(IModInterface *mod) {
       progress.show();
 
       archive.extractAll(
-          mod->absolutePath().toLocal8Bit().constData(),
+          mod->absolutePath().toStdWString().c_str(),
           [this, &progress](int value, std::string filename) {
             return extractProgress(progress, value, filename);
           },

--- a/src/bsaextractor.cpp
+++ b/src/bsaextractor.cpp
@@ -93,8 +93,8 @@ void BsaExtractor::modInstalledHandler(IModInterface *mod) {
              QDialogButtonBox::No) == QDialogButtonBox::Yes);
     foreach (QFileInfo archiveInfo, archives) {
       BSA::Archive archive;
-      BSA::EErrorCode result =
-          archive.read(archiveInfo.absoluteFilePath().toStdWString().c_str(), true);
+      BSA::EErrorCode result = archive.read(
+          archiveInfo.absoluteFilePath().toStdWString().c_str(), true);
       if ((result != BSA::ERROR_NONE) && (result != BSA::ERROR_INVALIDHASHES)) {
         reportError(tr("failed to read %1: %2")
                         .arg(archiveInfo.fileName())


### PR DESCRIPTION
Requirement of https://github.com/ModOrganizer2/modorganizer-bsatk/pull/27